### PR TITLE
Use of default credentials when AWS_VAULT env var is set

### DIFF
--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -1,7 +1,7 @@
 package utils
 
 type Args struct {
-	Profile, Target, Command, PortForward, RemoteHost string
+	Profile, Target, Command, PortForward, RemoteHost, Vault string
 }
 
 type Target struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -44,6 +44,7 @@ func BinaryName() string {
 func ParseFlags() Args {
 	args := Args{
 		Profile: os.Getenv("AWS_PROFILE"),
+		Vault: os.Getenv("AWS_VAULT"),
 	}
 
 	flaggy.String(&args.Profile, "p", "profile", "aws profile to use (defaults to value of AWS_PROFILE env var)")
@@ -58,8 +59,8 @@ func ParseFlags() Args {
 	if args.Target == "" {
 		flaggy.ShowHelpAndExit("required flag (-t --target) missing")
 	}
-	if args.Profile == "" {
-		flaggy.ShowHelpAndExit("required flag (-p --profile) missing and AWS profile could not be inferred from AWS_PROFILE env var")
+	if args.Profile == "" && args.Vault == "" {
+		flaggy.ShowHelpAndExit("required flag (-p --profile) missing and AWS profile could not be inferred from AWS_PROFILE env var and AWS_VAULT env var is not set")
 	}
 
 	return args


### PR DESCRIPTION
Allows for running arconn with aws-vault like so `aws-vault exec rue-netops-prod -- go run cmd/arconn/main.go -t i-04dae776e3edd4df6 -r goatruecommerce-replica01.goat.ruedev.com -P 3306`